### PR TITLE
fix: relaxed constraints on profile naming

### DIFF
--- a/git_remote_s3/common.py
+++ b/git_remote_s3/common.py
@@ -17,7 +17,7 @@ def parse_git_url(url: str) -> tuple[str, str, str]:
     """
     if url is None:
         return None, None, None
-    m = re.match(r"s3://([\w\-\+]{3,}@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
+    m = re.match(r"s3://([^@]+@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
     if m is None or len(m.groups()) != 3:
         return None, None, None
     profile, bucket, prefix = m.groups()

--- a/test/parse_url_test.py
+++ b/test/parse_url_test.py
@@ -25,6 +25,46 @@ def test_parse_url():
     assert prefix == "path/to"
 
 
+def test_parse_url_issue5():
+    url = "s3://er@bucket/path/"
+    profile, bucket, prefix = parse_git_url(url)
+    assert bucket == "bucket"
+    assert profile == "er"
+    assert prefix == "path"
+
+
+def test_parse_url_1_char_profile():
+    url = "s3://A@bucket/path/"
+    profile, bucket, prefix = parse_git_url(url)
+    assert bucket == "bucket"
+    assert profile == "A"
+    assert prefix == "path"
+
+
+def test_parse_url_all_supported_symbols_in_profile():
+    url = "s3://Ab-tr+54_quwww@bucket/path/"
+    profile, bucket, prefix = parse_git_url(url)
+    assert bucket == "bucket"
+    assert profile == "Ab-tr+54_quwww"
+    assert prefix == "path"
+
+
+def test_parse_url_unsupported_symbols_in_profile():
+    url = "s3://A!@bucket/path/"
+    profile, bucket, prefix = parse_git_url(url)
+    assert bucket == "bucket"
+    assert profile == "A!"
+    assert prefix == "path"
+
+
+def test_parse_url_empty_profile():
+    url = "s3://@bucket/path/"
+    profile, bucket, prefix = parse_git_url(url)
+    assert bucket is None
+    assert profile is None
+    assert prefix is None
+
+
 def test_parse_url_no_prefix_trailing_slash():
     url = "s3://profile-test@bucket-name/"
     profile, bucket, prefix = parse_git_url(url)


### PR DESCRIPTION
*Issue #, if available:*
#5 
*Description of changes:*
- Relaxed profile name regexp to accept any character but "@"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
