### PR TITLE
Optimize the costs by replacing `list_objects_v2` with `head_object`

### DIFF
--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -149,9 +149,10 @@ class S3Remote:
         Args:
             ref (str): The ref to which the remote HEAD should point to
         """
-        if not self.s3.list_objects_v2(
-            Bucket=self.bucket, Prefix=f"{self.prefix}/HEAD"
-        ).get("Contents", []):
+
+        try:
+            self.s3.head_object(Bucket=self.bucket, Key=f"{self.prefix}/HEAD")
+        except ClientError:
             self.s3.put_object(
                 Bucket=self.bucket,
                 Key=f"{self.prefix}/HEAD",
@@ -167,6 +168,9 @@ class S3Remote:
         Returns:
             list[str]: the list of bundle keys
         """
+
+        # We are not implementing pagination since there can be few objects (bundles)
+        # under a single Prefix
         return [
             c
             for c in self.s3.list_objects_v2(


### PR DESCRIPTION
*Issue #, if available:*
Resolves #9

*Description of changes:*
At every push the code checks if there is an HEAD object using `list_objects_v2` API call (LIST operation) that costs $0.000005 per request. We replace it with an `head_object` API call (HEAD operation) that costs less than 1/10th of the LIST operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
