### PR TITLE
Remove erroneous `list_object_v2` call

### DIFF
--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -57,9 +57,6 @@ class S3Remote:
             contents.extend(res.get("Contents", []))
             next_token = res.get("NextContinuationToken", None)
 
-        contents = self.s3.list_objects_v2(Bucket=bucket, Prefix=prefix).get(
-            "Contents", []
-        )
         contents.sort(key=lambda x: x["LastModified"])
         contents.reverse()
 


### PR DESCRIPTION
*Issue #, if available:*
Resolves #8 

*Description of changes:*
Remove the duplicate and erroneous `list_object_v2` call from `list_refs`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
