### PR TITLE
feat: Create and upload zip archive on git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ It provides an implementation of a [git remote helper](https://git-scm.com/docs/
 
 It also provide an implementation of the [git-lfs custom transfer](https://github.com/git-lfs/git-lfs/blob/main/docs/custom-transfers.md) to enable pushing LFS managed files to the same S3 bucket used as remote.
 
+## Table of Contents
+
+* [Installation](#installation)
+* [Prerequisites](#prerequisites)
+* [Security](#security)
+  * [Data encryption](#data-encryption)
+  * [Access control](#access-control)
+* [Use S3 remotes](#use-s3-remotes)
+  * [Create a new repo](#create-a-new-repo)
+  * [Clone a repo](#clone-a-repo)
+  * [Branches, etc.](#branches-etc)
+* [Repo as S3 Source for AWS CodePipeline](#repo-as-s3-source-for-aws-codepipeline)
+  * [Archive file location](#archive-file-location)
+  * [Example AWS CodePipeline source action config](#example-aws-codepipeline-source-action-config)
+* [LFS](#lfs)
+  * [Creating the repo and pushing](#creating-the-repo-and-pushing)
+  * [Clone the repo](#clone-the-repo)
+* [Notes about specific behaviors of Amazon S3 remotes](#notes-about-specific-behaviors-of-amazon-s3-remotes)
+  * [Arbitrary Amazon S3 URIs](#arbitrary-amazon-s3-uris)
+  * [Concurrent writes](#concurrent-writes)
+* [Manage the Amazon S3 remote](#manage-the-amazon-s3-remote)
+  * [Delete branches](#delete-branches)
+  * [Protected branches](#protected-branches)
+* [Under the hood](#under-the-hood)
+  * [How S3 remote work](#how-s3-remote-work)
+  * [How LFS work](#how-lfs-work)
+  * [Debugging](#debugging)
+* [Credits](#credits)
+
 ## Installation
 
 `git-remote-s3` is a Python script and works with any Python version >= 3.9.
@@ -66,9 +95,9 @@ Access control to the remote is ensured via IAM permissions, and can be controll
 - prefix level (you can use prefixes to store multiple repos in the same S3 bucket thus minimizing the setup effort)
 - KMS key level
 
-# Use S3 remotes
+## Use S3 remotes
 
-## Create a new repo
+### Create a new repo
 
 S3 remotes are identified by the prefix `s3://` and at the bare minimum specify the name of the bucket. You can also provide a key prefix as in `s3://my-git-bucket/my-repo` and a profile `s3://my-profile@my-git-bucket/myrepo`.
 
@@ -92,7 +121,7 @@ The remote HEAD is set to track the branch that has been pushed first to the rem
 
 When you use `s3+zip://` instead of `s3://`, an additional zip archive named `repo.zip` is uploaded next to the `sha.bundle` file.  This is for example useful if you want to use the Repo as a S3 Source for AWS CodePipeline, which expects a `.zip` file. The path on S3 when you push to the `main` branch is for example `refs/heads/main/repo.zip`. See [How S3 remote work](#how-s3-remote-work) for more details about the bundle file.
 
-## Clone a repo
+### Clone a repo
 
 To clone the repo to another folder just use the normal git syntax using the s3 URI as remote:
 
@@ -100,7 +129,7 @@ To clone the repo to another folder just use the normal git syntax using the s3 
 git clone s3://my-git-bucket/my-repo my-repo-clone
 ```
 
-## Branches, etc.
+### Branches, etc.
 
 Creating branches and pushing them works as normal:
 
@@ -115,7 +144,33 @@ git push origin new_branch
 
 All git operations that do not rely on communication with the server should work as usual (eg `git merge`)
 
-# LFS
+## Repo as S3 Source for AWS CodePipeline
+
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) offers an [Amazon S3 source action](https://docs.aws.amazon.com/codepipeline/latest/userguide/integrations-action-type.html#integrations-source-s3) 
+as location for your source code and application files. But this requires to `uploade the source files as a single ZIP file`. 
+As briefly mentioned in [Create a new repo](#create-a-new-repo), `git-remote-s3` can create and upload zip archives. 
+When you use `s3+zip` as URI Scheme when you add the remote, `git-remote-s3` will automatically upload an archive that can be used by AWS CodePipeline.
+
+### Archive file location
+
+Let's assume your bucket name is `my-git-bucket` and the repo is called `my-repo`. Run `git remote add origin s3+zip://my-git-bucket/my-repo` to use it as remote. 
+When you now commit your changes and push to the remote, an additional `repo.zip` file will be uploaded to the bucket. 
+For example, if you push to the `main` branch (`git push origin main`), the file is available under `s3://my-git-bucket/my-repo/refs/heads/main/repo.zip`. 
+When you push to a branch called `fix_a_bug` it's available under `s3://my-git-bucket/my-repo/refs/heads/fix_a_bug/repo.zip`. 
+And if you create and push a tag called `v1.0` it will be `s3://my-git-bucket/my-repo/refs/tags/v1.0/repo.zip`.
+
+### Example AWS CodePipeline source action config
+
+Your AWS CodePipeline Action configuration to trigger when you update your `main` branch:
+
+- Action Provider: `Amazon S3`
+- Bucket: `my-git-bucket`
+- S3 object key: `s3://my-git-bucket/my-repo my-repo-clone`
+- Change detection options: `AWS CodePipeline`
+
+Visit [Tutorial: Create a simple pipeline (S3 bucket)](https://docs.aws.amazon.com/codepipeline/latest/userguide/tutorials-simple-s3.html) to learn more about a S3 bucket as source action.
+
+## LFS
 
 To use LFS you need to first install git-lfs. You can refer to the [official documentation](https://git-lfs.com/) on how to do this on your system.
 
@@ -131,8 +186,6 @@ which is a short cut for:
 git config --add lfs.customtransfer.lfs-s3-py.path lfs-s3-py
 git config --add lfs.standalonetransferagent lfs-s3-py
 ```
-
-## Example use
 
 ### Creating the repo and pushing
 
@@ -152,46 +205,6 @@ git commit -a -m "my first tiff file"
 git remote add origin s3://my-git-bucket/lfs-repo
 git push --set-upstream origin main
 ```
-
-## Notes about specific behaviors of Amazon S3 remotes
-
-### Arbitrary Amazon S3 URIs
-
-An Amazon S3 URI for an valid bucket and an arbitrary prefix which does not contain the right structure under it, is considered valid.
-
-`git ls-remote` returns an empty list and `git clone` clones an empty repository for which the S3 URI is set as remote origin.
-
-```
-% git clone s3://my-git-bucket/this-is-a-new-repo
-Cloning into 'this-is-a-new-repo'...
-warning: You appear to have cloned an empty repository.
-% cd this-is-a-new-repo
-% git remote -v
-origin  s3://my-git-bucket/this-is-a-new-repo (fetch)
-origin  s3://my-git-bucket/this-is-a-new-repo (push)
-```
-
-**Tip**: This behavior can be used to quickly create a new git repo.
-
-## Concurrent writes
-
-Due to the distributed nature of `git`, there might be cases (albeit rare) where 2 or more `git push` are executed at the same time by different user with their own modification of the same branch.
-
-The git command executes the push in 2 steps:
-
-1. first it checks if the remote reference is the correct ancestor for the commit being pushed
-2. if that is correct it invokes the `git-remote-s3` command which writes the bundle to the S3 bucket at the `refs/heads/<branch>` path
-
-In case two (or more) `git push` command are executed at the same time from different clients, at step 1 the same valid ref is fetched, hence both clients proceed with step 2, resulting in multiple bundles being stored in S3.
-
-The branch has now multiple head references, and any subsequent `git push` fails with the error:
-
-```
-error: dst refspec refs/heads/<branch>> matches more than one
-error: failed to push some refs to 's3://<bucket>/<prefix>'
-```
-
-To fix this issue, run the `git-remote-s3 doctor <s3-uri>` command. By default it will create a new branch for every bundle that should not be retained. The user can then checkout the branch locally and merge it to the original branch. If you want instead to remove the bundle, specify `--delete-bundle`.
 
 ### Clone the repo
 
@@ -213,19 +226,59 @@ lfs-s3-py install
 git reset --hard main
 ```
 
-# Manage the Amazon S3 remote
+## Notes about specific behaviors of Amazon S3 remotes
 
-## Delete branches
+### Arbitrary Amazon S3 URIs
+
+An Amazon S3 URI for a valid bucket and an arbitrary prefix which does not contain the right structure under it, is considered valid.
+
+`git ls-remote` returns an empty list and `git clone` clones an empty repository for which the S3 URI is set as remote origin.
+
+```
+% git clone s3://my-git-bucket/this-is-a-new-repo
+Cloning into 'this-is-a-new-repo'...
+warning: You appear to have cloned an empty repository.
+% cd this-is-a-new-repo
+% git remote -v
+origin  s3://my-git-bucket/this-is-a-new-repo (fetch)
+origin  s3://my-git-bucket/this-is-a-new-repo (push)
+```
+
+**Tip**: This behavior can be used to quickly create a new git repo.
+
+### Concurrent writes
+
+Due to the distributed nature of `git`, there might be cases (albeit rare) where 2 or more `git push` are executed at the same time by different user with their own modification of the same branch.
+
+The git command executes the push in 2 steps:
+
+1. first it checks if the remote reference is the correct ancestor for the commit being pushed
+2. if that is correct it invokes the `git-remote-s3` command which writes the bundle to the S3 bucket at the `refs/heads/<branch>` path
+
+In case two (or more) `git push` command are executed at the same time from different clients, at step 1 the same valid ref is fetched, hence both clients proceed with step 2, resulting in multiple bundles being stored in S3.
+
+The branch has now multiple head references, and any subsequent `git push` fails with the error:
+
+```
+error: dst refspec refs/heads/<branch>> matches more than one
+error: failed to push some refs to 's3://<bucket>/<prefix>'
+```
+
+To fix this issue, run the `git-remote-s3 doctor <s3-uri>` command. By default it will create a new branch for every bundle that should not be retained. The user can then checkout the branch locally and merge it to the original branch. If you want instead to remove the bundle, specify `--delete-bundle`.
+
+## Manage the Amazon S3 remote
+
+### Delete branches
 
 To remove remote branches that are not used anymore you can use the `git-s3 delete-branch <s3uri> -b <branch_name>` command. This command deletes the bundle object(s) from Amazon S3 under the branch path.
 
-## Protected branches
+### Protected branches
 
 To protect/unprotect a branch run `git s3 protect <remote> <branch-name>` respectively `git s3 unprotect <remote> <branch-name>`.
 
-# Under the hood
+## Under the hood
 
-## How S3 remote work
+### How S3 remote work
 
 Bundles are stored in the S3 bucket as `<prefix>/<ref>/<sha>.bundle`.
 
@@ -238,19 +291,19 @@ If the push is successful, the code removes the previous bundle associated to th
 If two user concurrently push a commit based on the same current branch head to the remote both bundles would be written to the repo and the current bundle removed. No data is lost, but no further push will be possible until all bundles but one are removed.
 For this you can use the `git s3 doctor <remote>` command.
 
-## How LFS work
+### How LFS work
 
 The LFS integration stores the file in the bucket defined by the remote URI, under a key `<prefix>/lfs/<oid>`, where oid is the unique identifier assigned by git-lfs to the file.
 
 If an object with the same key already exists, git-lfs-s3 does not upload it again.
 
-## Debugging
+### Debugging
 
 Use `--verbose` flag to print some debug information when performing git operations. Logs will be put to stderr.
 
 For LFS operations you can enable and disable debug logging via `git-lfs-s3 enable-debug` and `git-lfs-s3 disable-debug` respectively. Logs are put in `.git/lfs/tmp/git-lfs-s3.log` in the repo.
 
-# Credits
+## Credits
 
 The git S3 integration was inspired by the work of Bryan Gahagan on [git-remote-s3](https://github.com/bgahagan/git-remote-s3).
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ git push --set-upstream origin main
 
 The remote HEAD is set to track the branch that has been pushed first to the remote repo. To change the remote HEAD branch, delete the HEAD object `s3://<bucket>/<prefix>/HEAD` and then run `git-remote-s3 doctor s3://<bucket>/<prefix>`.
 
+When you use `s3+zip://` instead of `s3://`, an additional zip archive named `repo.zip` is uploaded next to the `sha.bundle` file.  This is for example useful if you want to use the Repo as a S3 Source for AWS CodePipeline, which expects a `.zip` file. The path on S3 when you push to the `main` branch is for example `refs/heads/main/repo.zip`. See [How S3 remote work](#how-s3-remote-work) for more details about the bundle file.
+
 ## Clone a repo
 
 To clone the repo to another folder just use the normal git syntax using the s3 URI as remote:

--- a/git_remote_s3/__init__.py
+++ b/git_remote_s3/__init__.py
@@ -5,10 +5,12 @@ from .remote import S3Remote
 from . import git
 from .common import parse_git_url
 from .manage import Doctor
+from .enums import UriScheme
 
 __all__ = [
     "S3Remote",
     "git",
     "parse_git_url",
     "Doctor",
+    "UriScheme"
 ]

--- a/git_remote_s3/common.py
+++ b/git_remote_s3/common.py
@@ -5,24 +5,24 @@
 import re
 
 
-def parse_git_url(url: str) -> tuple[str, str, str]:
+def parse_git_url(url: str) -> tuple[str, str, str, str]:
     """Parses the elements in an s3:// remote origin URI
 
     Args:
         url (str): the URI to parse
 
     Returns:
-        tuple[str, str, str]: prefix, bucket and profile extracted from the URI or
-        None, None, None if the URI is invalid
+        tuple[str, str, str, str]: uri scheme, prefix, bucket and profile extracted
+        from the URI or None, None, None, None if the URI is invalid
     """
     if url is None:
-        return None, None, None
-    m = re.match(r"s3://([^@]+@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
-    if m is None or len(m.groups()) != 3:
-        return None, None, None
-    profile, bucket, prefix = m.groups()
+        return None, None, None, None
+    m = re.match(r"(s3.*)://([^@]+@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
+    if m is None or len(m.groups()) != 4:
+        return None, None, None, None
+    uri_scheme, profile, bucket, prefix = m.groups()
     if profile is not None:
         profile = profile[:-1]
     if prefix is not None:
         prefix = prefix.strip("/")
-    return profile, bucket, prefix
+    return uri_scheme, profile, bucket, prefix

--- a/git_remote_s3/common.py
+++ b/git_remote_s3/common.py
@@ -4,9 +4,11 @@
 
 import re
 
+from .enums import UriScheme
 
-def parse_git_url(url: str) -> tuple[str, str, str, str]:
-    """Parses the elements in an s3:// remote origin URI
+
+def parse_git_url(url: str) -> tuple[UriScheme, str, str, str]:
+    """Parses the elements in a s3:// remote origin URI
 
     Args:
         url (str): the URI to parse
@@ -17,7 +19,7 @@ def parse_git_url(url: str) -> tuple[str, str, str, str]:
     """
     if url is None:
         return None, None, None, None
-    m = re.match(r"(s3.*)://([^@]+@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
+    m = re.match(r"(s3|s3\+zip)://([^@]+@)?([a-z0-9][a-z0-9\.-]{2,62})/?(.+)?", url)
     if m is None or len(m.groups()) != 4:
         return None, None, None, None
     uri_scheme, profile, bucket, prefix = m.groups()
@@ -25,4 +27,10 @@ def parse_git_url(url: str) -> tuple[str, str, str, str]:
         profile = profile[:-1]
     if prefix is not None:
         prefix = prefix.strip("/")
+    if uri_scheme is not None:
+        if uri_scheme == "s3":
+            uri_scheme = UriScheme.S3
+        if uri_scheme == "s3+zip":
+            uri_scheme = UriScheme.S3_ZIP
+
     return uri_scheme, profile, bucket, prefix

--- a/git_remote_s3/enums.py
+++ b/git_remote_s3/enums.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Amazon.com, Inc. or its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+
+
+class UriScheme(Enum):
+    S3 = "s3"
+    S3_ZIP = "s3+zip"

--- a/git_remote_s3/git.py
+++ b/git_remote_s3/git.py
@@ -11,6 +11,31 @@ class GitError(Exception):
     pass
 
 
+def archive(*, folder: str, ref: str) -> str:
+    """Archive the content of the folder into a repo.zip file
+
+    Args:
+        folder (str): the folder to archive
+        ref (str): the ref to archive
+
+    Returns:
+        str: the path to the archive file
+    """
+
+    file_path = f"{folder}/repo.zip"
+    result = subprocess.run(
+        ["git", "archive", "--format", "zip", "--output", file_path, ref],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    if result.returncode == 0:
+        return file_path
+    else:
+        raise GitError(result.stderr.decode("utf8"))
+
+
 def bundle(*, folder: str, sha: str, ref: str) -> str:
     """Bundles the content of the folder into a sha.bundle file
 

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -54,7 +54,7 @@ def write_error_event(*, oid: str, error: str, flush=False):
 
 class LFSProcess:
     def __init__(self, s3uri: str):
-        profile, bucket, prefix = parse_git_url(s3uri)
+        uri_scheme, profile, bucket, prefix = parse_git_url(s3uri)
         if bucket is None or prefix is None:
             logger.error(f"s3 uri {s3uri} is invalid")
             error_event = {

--- a/git_remote_s3/manage.py
+++ b/git_remote_s3/manage.py
@@ -220,7 +220,7 @@ def main():
         sys.stderr.flush()
         sys.exit(1)
 
-    profile, bucket, prefix = parse_git_url(remote_url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(remote_url)
     try:
         if args.command == "doctor":
             doctor = Doctor(profile, bucket, prefix, args.delete_bundle)

--- a/git_remote_s3/manage.py
+++ b/git_remote_s3/manage.py
@@ -89,7 +89,7 @@ class Doctor:
         print(f"\nFix multiple bundles for repo {r} and ref {ref}")
         bundles = repos[r]["refs"][ref]["bundles"]
         for i, sha in enumerate(bundles):
-            print(f"{i+1}. {sha['sha']} {sha['lastModified']}")
+            print(f"{i + 1}. {sha['sha']} {sha['lastModified']}")
         while True:
             try:
                 i = int(input("Enter the number of the bundle to keep: "))
@@ -128,7 +128,7 @@ class Doctor:
         print(f"\nFix invalid HEAD for repo {r}")
         heads = [k for k in repos[r]["refs"].keys() if "heads" in k]
         for i, head in enumerate(heads):
-            print(f"{i+1}. {head.split('/')[-1]}")
+            print(f"{i + 1}. {head.split('/')[-1]}")
         while True:
             try:
                 i = int(input("Enter the number of the branch to use as head: "))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [tool.poetry.scripts]
 git-remote-s3 = "git_remote_s3.remote:main"
+"git-remote-s3+zip" = "git_remote_s3.remote:main"
 git-lfs-s3 = "git_remote_s3.lfs:main"
 git-s3 = "git_remote_s3.manage:main"
 

--- a/test/parse_url_test.py
+++ b/test/parse_url_test.py
@@ -1,9 +1,9 @@
 from git_remote_s3 import parse_git_url
 
-
 def test_parse_url_trailing_slash_no_profile():
     url = "s3://bucket-name/path/to/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix == "path/to"
@@ -11,7 +11,8 @@ def test_parse_url_trailing_slash_no_profile():
 
 def test_parse_url_no_profile():
     url = "s3://bucket-name/path/to"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix == "path/to"
@@ -19,7 +20,8 @@ def test_parse_url_no_profile():
 
 def test_parse_url():
     url = "s3://profile-test@bucket-name/path/to"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix == "path/to"
@@ -27,7 +29,8 @@ def test_parse_url():
 
 def test_parse_url_issue5():
     url = "s3://er@bucket/path/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket"
     assert profile == "er"
     assert prefix == "path"
@@ -35,7 +38,8 @@ def test_parse_url_issue5():
 
 def test_parse_url_1_char_profile():
     url = "s3://A@bucket/path/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket"
     assert profile == "A"
     assert prefix == "path"
@@ -43,7 +47,8 @@ def test_parse_url_1_char_profile():
 
 def test_parse_url_all_supported_symbols_in_profile():
     url = "s3://Ab-tr+54_quwww@bucket/path/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket"
     assert profile == "Ab-tr+54_quwww"
     assert prefix == "path"
@@ -51,7 +56,8 @@ def test_parse_url_all_supported_symbols_in_profile():
 
 def test_parse_url_unsupported_symbols_in_profile():
     url = "s3://A!@bucket/path/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket"
     assert profile == "A!"
     assert prefix == "path"
@@ -59,7 +65,8 @@ def test_parse_url_unsupported_symbols_in_profile():
 
 def test_parse_url_empty_profile():
     url = "s3://@bucket/path/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme is None
     assert bucket is None
     assert profile is None
     assert prefix is None
@@ -67,7 +74,8 @@ def test_parse_url_empty_profile():
 
 def test_parse_url_no_prefix_trailing_slash():
     url = "s3://profile-test@bucket-name/"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix is None
@@ -75,7 +83,8 @@ def test_parse_url_no_prefix_trailing_slash():
 
 def test_parse_url_no_prefix():
     url = "s3://profile-test@bucket-name"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix is None
@@ -83,7 +92,8 @@ def test_parse_url_no_prefix():
 
 def test_parse_url_no_prefix_no_profile():
     url = "s3://bucket-name"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3"
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix is None
@@ -91,7 +101,8 @@ def test_parse_url_no_prefix_no_profile():
 
 def test_parse_url_not_valid():
     url = "s4://bucket-name/path/to"
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme is None
     assert bucket is None
     assert profile is None
     assert prefix is None
@@ -99,7 +110,25 @@ def test_parse_url_not_valid():
 
 def test_parse_url_none():
     url = None
-    profile, bucket, prefix = parse_git_url(url)
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme is None
     assert bucket is None
     assert profile is None
     assert prefix is None
+
+
+def test_parse_url_uri_scheme_s3_zip_no_profile():
+    url = "s3+zip://bucket-name/path/to"
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3+zip"
+    assert bucket == "bucket-name"
+    assert profile is None
+    assert prefix == "path/to"
+
+def test_parse_url_uri_scheme_s3_zip():
+    url = "s3+zip://profile-test@bucket-name/path/to"
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme == "s3+zip"
+    assert bucket == "bucket-name"
+    assert profile == "profile-test"
+    assert prefix == "path/to"

--- a/test/parse_url_test.py
+++ b/test/parse_url_test.py
@@ -1,9 +1,10 @@
-from git_remote_s3 import parse_git_url
+from git_remote_s3 import parse_git_url, UriScheme
+
 
 def test_parse_url_trailing_slash_no_profile():
     url = "s3://bucket-name/path/to/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix == "path/to"
@@ -12,7 +13,7 @@ def test_parse_url_trailing_slash_no_profile():
 def test_parse_url_no_profile():
     url = "s3://bucket-name/path/to"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix == "path/to"
@@ -21,7 +22,7 @@ def test_parse_url_no_profile():
 def test_parse_url():
     url = "s3://profile-test@bucket-name/path/to"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix == "path/to"
@@ -30,7 +31,7 @@ def test_parse_url():
 def test_parse_url_issue5():
     url = "s3://er@bucket/path/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket"
     assert profile == "er"
     assert prefix == "path"
@@ -39,7 +40,7 @@ def test_parse_url_issue5():
 def test_parse_url_1_char_profile():
     url = "s3://A@bucket/path/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket"
     assert profile == "A"
     assert prefix == "path"
@@ -48,7 +49,7 @@ def test_parse_url_1_char_profile():
 def test_parse_url_all_supported_symbols_in_profile():
     url = "s3://Ab-tr+54_quwww@bucket/path/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket"
     assert profile == "Ab-tr+54_quwww"
     assert prefix == "path"
@@ -57,7 +58,7 @@ def test_parse_url_all_supported_symbols_in_profile():
 def test_parse_url_unsupported_symbols_in_profile():
     url = "s3://A!@bucket/path/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket"
     assert profile == "A!"
     assert prefix == "path"
@@ -75,7 +76,7 @@ def test_parse_url_empty_profile():
 def test_parse_url_no_prefix_trailing_slash():
     url = "s3://profile-test@bucket-name/"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix is None
@@ -84,7 +85,7 @@ def test_parse_url_no_prefix_trailing_slash():
 def test_parse_url_no_prefix():
     url = "s3://profile-test@bucket-name"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix is None
@@ -93,7 +94,7 @@ def test_parse_url_no_prefix():
 def test_parse_url_no_prefix_no_profile():
     url = "s3://bucket-name"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3"
+    assert uri_scheme == UriScheme.S3
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix is None
@@ -120,15 +121,25 @@ def test_parse_url_none():
 def test_parse_url_uri_scheme_s3_zip_no_profile():
     url = "s3+zip://bucket-name/path/to"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3+zip"
+    assert uri_scheme == UriScheme.S3_ZIP
     assert bucket == "bucket-name"
     assert profile is None
     assert prefix == "path/to"
 
+
 def test_parse_url_uri_scheme_s3_zip():
     url = "s3+zip://profile-test@bucket-name/path/to"
     uri_scheme, profile, bucket, prefix = parse_git_url(url)
-    assert uri_scheme == "s3+zip"
+    assert uri_scheme == UriScheme.S3_ZIP
     assert bucket == "bucket-name"
     assert profile == "profile-test"
     assert prefix == "path/to"
+
+
+def test_parse_url_uri_scheme_not_valid():
+    url = "s3+foo://bucket-name/path/to"
+    uri_scheme, profile, bucket, prefix = parse_git_url(url)
+    assert uri_scheme is None
+    assert bucket is None
+    assert profile is None
+    assert prefix is None

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -1,7 +1,7 @@
 import botocore.client
 from mock import patch
 from io import StringIO, BytesIO
-from git_remote_s3 import S3Remote
+from git_remote_s3 import S3Remote, UriScheme
 from botocore.exceptions import ClientError
 import tempfile
 import datetime
@@ -55,7 +55,7 @@ def create_list_objects_v2_mock(
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_list(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.side_effect = (
         create_list_objects_v2_mock(shas=[SHA1])
@@ -76,7 +76,7 @@ def test_cmd_list(session_client_mock, stdout_mock):
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_list_no_head(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.side_effect = (
         create_list_objects_v2_mock(shas=[SHA1], no_head=True)
@@ -99,7 +99,7 @@ def test_cmd_list_no_head(session_client_mock, stdout_mock):
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_list_with_head_not_exsting_ref(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.side_effect = (
         create_list_objects_v2_mock(shas=[SHA1])
@@ -118,7 +118,7 @@ def test_cmd_list_with_head_not_exsting_ref(session_client_mock, stdout_mock):
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_list_protected_branch(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.side_effect = (
         create_list_objects_v2_mock(protected=True, shas=[SHA1])
@@ -144,7 +144,7 @@ def test_cmd_list_protected_branch(session_client_mock, stdout_mock):
 def test_cmd_push_no_force_unprotected_ancestor(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -169,7 +169,7 @@ def test_cmd_push_no_force_unprotected_ancestor(
 def test_cmd_push_no_force_unprotected_ancestor_s3_zip(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3+zip", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3_ZIP, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -194,7 +194,7 @@ def test_cmd_push_no_force_unprotected_ancestor_s3_zip(
 def test_cmd_push_no_force_unprotected_no_ancestor(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -220,7 +220,7 @@ def test_cmd_push_no_force_unprotected_no_ancestor(
 def test_cmd_push_force_no_ancestor(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -245,7 +245,7 @@ def test_cmd_push_force_no_ancestor(
 def test_cmd_push_force_no_ancestor_s3_zip(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3+zip", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3_ZIP, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -270,7 +270,7 @@ def test_cmd_push_force_no_ancestor_s3_zip(
 def test_cmd_push_force_no_ancestor_protected(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -295,7 +295,7 @@ def test_cmd_push_force_no_ancestor_protected(
 def test_cmd_push_empty_bucket(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -322,7 +322,7 @@ def test_cmd_push_empty_bucket(
 def test_cmd_push_empty_bucket_s3_zip(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3+zip", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3_ZIP, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -349,7 +349,7 @@ def test_cmd_push_empty_bucket_s3_zip(
 def test_cmd_push_multiple_heads(
     session_client_mock, bundle_mock, rev_parse_mock, is_ancestor_mock
 ):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     rev_parse_mock.return_value = SHA1
     temp_dir = tempfile.mkdtemp("test_temp")
     temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, suffix=BUNDLE_SUFFIX)
@@ -370,7 +370,7 @@ def test_cmd_push_multiple_heads(
 @patch("git_remote_s3.git.unbundle")
 @patch("boto3.Session.client")
 def test_cmd_fetch(session_client_mock, unbundle_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     session_client_mock.return_value.get_object.return_value = {
         "Body": BytesIO(MOCK_BUNDLE_CONTENT)
     }
@@ -383,7 +383,7 @@ def test_cmd_fetch(session_client_mock, unbundle_mock):
 @patch("git_remote_s3.git.unbundle")
 @patch("boto3.Session.client")
 def test_cmd_fetch_same_ref(session_client_mock, unbundle_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     session_client_mock.return_value.get_object.return_value = {
         "Body": BytesIO(MOCK_BUNDLE_CONTENT)
     }
@@ -396,7 +396,7 @@ def test_cmd_fetch_same_ref(session_client_mock, unbundle_mock):
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_option(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     s3_remote.cmd_option("option verbosity 2")
     assert stdout_mock.getvalue().startswith("ok\n")
     s3_remote.cmd_option("option concurrency 1")
@@ -406,7 +406,7 @@ def test_cmd_option(session_client_mock, stdout_mock):
 @patch("sys.stdout", new_callable=StringIO)
 @patch("boto3.Session.client")
 def test_cmd_capabilities(session_client_mock, stdout_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
     s3_remote.cmd_capabilities()
     assert "fetch" in stdout_mock.getvalue()
     assert "option" in stdout_mock.getvalue()
@@ -415,7 +415,7 @@ def test_cmd_capabilities(session_client_mock, stdout_mock):
 
 @patch("boto3.Session.client")
 def test_cmd_push_delete(session_client_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.return_value = {
         "Contents": [
@@ -432,8 +432,30 @@ def test_cmd_push_delete(session_client_mock):
 
 
 @patch("boto3.Session.client")
+def test_cmd_push_delete_s3_zip(session_client_mock):
+    s3_remote = S3Remote(UriScheme.S3_ZIP, None, "test_bucket", "test_prefix")
+
+    session_client_mock.return_value.list_objects_v2.return_value = {
+        "Contents": [
+            {
+                "Key": f"test_prefix/refs/heads/main/{SHA1}.bundle",
+                "LastModified": datetime.datetime.now(),
+            },
+            {
+                "Key": "test_prefix/refs/heads/main/repo.zip",
+                "LastModified": datetime.datetime.now(),
+            }
+        ]
+    }
+    assert s3_remote.s3 == session_client_mock.return_value
+    res = s3_remote.cmd_push("push :refs/heads/main")
+    assert session_client_mock.return_value.delete_object.call_count == 2
+    assert res == ("ok refs/heads/main\n")
+
+
+@patch("boto3.Session.client")
 def test_cmd_push_delete_fails_with_multiple_heads(session_client_mock):
-    s3_remote = S3Remote("s3", None, "test_bucket", "test_prefix")
+    s3_remote = S3Remote(UriScheme.S3, None, "test_bucket", "test_prefix")
 
     session_client_mock.return_value.list_objects_v2.return_value = {
         "Contents": [
@@ -445,6 +467,32 @@ def test_cmd_push_delete_fails_with_multiple_heads(session_client_mock):
                 "Key": f"test_prefix/refs/heads/main/{SHA2}.bundle",
                 "LastModified": datetime.datetime.now(),
             },
+        ]
+    }
+    assert s3_remote.s3 == session_client_mock.return_value
+    res = s3_remote.cmd_push("push :refs/heads/main")
+    assert session_client_mock.return_value.delete_object.call_count == 0
+    assert res.startswith("error")
+
+
+@patch("boto3.Session.client")
+def test_cmd_push_delete_fails_with_multiple_heads_s3_zip(session_client_mock):
+    s3_remote = S3Remote(UriScheme.S3_ZIP, None, "test_bucket", "test_prefix")
+
+    session_client_mock.return_value.list_objects_v2.return_value = {
+        "Contents": [
+            {
+                "Key": f"test_prefix/refs/heads/main/{SHA1}.bundle",
+                "LastModified": datetime.datetime.now(),
+            },
+            {
+                "Key": f"test_prefix/refs/heads/main/{SHA2}.bundle",
+                "LastModified": datetime.datetime.now(),
+            },
+            {
+                "Key": "test_prefix/refs/heads/main/repo.zip",
+                "LastModified": datetime.datetime.now(),
+            }
         ]
     }
     assert s3_remote.s3 == session_client_mock.return_value

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -157,7 +157,7 @@ def test_cmd_push_no_force_unprotected_ancestor(
     is_ancestor_mock.return_value = True
     assert s3_remote.s3 == session_client_mock.return_value
     res = s3_remote.cmd_push("push refs/heads/main:refs/heads/main")
-    assert session_client_mock.return_value.put_object.call_count == 1
+    assert session_client_mock.return_value.put_object.call_count == 2
     assert session_client_mock.return_value.delete_object.call_count == 1
     assert res == ("ok refs/heads/main\n")
 
@@ -208,7 +208,7 @@ def test_cmd_push_force_no_ancestor(
     is_ancestor_mock.return_value = False
     assert s3_remote.s3 == session_client_mock.return_value
     res = s3_remote.cmd_push("push +refs/heads/main:refs/heads/main")
-    assert session_client_mock.return_value.put_object.call_count == 1
+    assert session_client_mock.return_value.put_object.call_count == 2
     assert session_client_mock.return_value.delete_object.call_count == 1
     assert res.startswith("ok")
 
@@ -260,7 +260,7 @@ def test_cmd_push_empty_bucket(
     is_ancestor_mock.return_value = False
     assert s3_remote.s3 == session_client_mock.return_value
     res = s3_remote.cmd_push("push refs/heads/main:refs/heads/main")
-    assert session_client_mock.return_value.put_object.call_count == 2
+    assert session_client_mock.return_value.put_object.call_count == 3
     assert session_client_mock.return_value.delete_object.call_count == 0
     assert res.startswith("ok")
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

In addition to the `sha.bundle` file, a `repo.zip` file gets created and uploaded into the same remote refs path.

Example use-case: Use a `git-remote-s3` repo as `S3 Source` in `AWS CodePipeline` by pointing to the `repo.zip` file which will be updated on each push.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
