### PR TITLE
Correct handling of multilevel paths in S3 prefixes

### DIFF
--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -75,7 +75,7 @@ class S3Remote:
         contents.reverse()
 
         objs = [
-            o["Key"][o["Key"].index("/") + 1 :]
+            o["Key"].removeprefix(prefix)[1:]
             for o in contents
             if o["Key"].startswith(prefix + "/refs") and o["Key"].endswith(".bundle")
         ]


### PR DESCRIPTION
*Issue #, if available:*
Resolves #18 

*Description of changes:*
- Added test for multilevel paths in S3 prefixes
- Modified code to correctly strip multilevel paths prefixes from object keys returned from S3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
