### PR TITLE
Add s3:DeleteObject to recommended policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ Before you can use `git-remote-s3`, you must:
   {
     "Sid": "S3Access",
     "Effect": "Allow",
-    "Action": ["s3:PutObject", "s3:GetObject", "s3:ListBucket"],
+    "Action": [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:DeleteObject"
+    ],
     "Resource": ["arn:aws:s3:::<BUCKET>", "arn:aws:s3:::*/*"]
   }
   ```


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
I was able to push successfully the first time using the recommended IAM policy, but pushing the second time resulted in the error:

```
! [remote rejected] origin/main -> origin/main (An error occurred (AccessDenied) when calling the DeleteObject operation: User: arn:aws:sts::XYZ:assumed-role/XYZ is not authorized to perform: s3:DeleteObject on resource: )
! [remote rejected] main -> main (An error occurred (AccessDenied) when calling the DeleteObject operation: User: arn:aws:sts::XYZ:assumed-role/XYZ is not authorized to perform: s3:DeleteObject on resource: )
```

This PR updates the sample policy to include s3:DeleteObject.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
