### PR TITLE
Add commit information to S3 object metadata

### DIFF
--- a/git_remote_s3/git.py
+++ b/git_remote_s3/git.py
@@ -134,3 +134,13 @@ def validate_ref_name(name: str) -> bool:
         )
         is None
     )
+
+
+def get_last_commit_message() -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--pretty=%h %s"], stdout=subprocess.PIPE
+    )
+    if result.returncode != 0:
+        raise GitError(f"fatal: an error as occurred")
+    message = result.stdout.decode("utf8").strip()
+    return message


### PR DESCRIPTION
Resolves #25

*Description of changes:*
When using the `s3+zip` schema, we are adding the latest short commit hash and message as `"codepipeline-artifact-revision-summary"` to the `repo.zip` object metadata.

This message is then associated with the CodePipeline source trigger (see https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_SourceRevision.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
