### PR TITLE
Clarification on bucket permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,27 @@ Before you can use `git-remote-s3`, you must:
 
   ```json
   {
-    "Sid": "S3Access",
-    "Effect": "Allow",
-    "Action": [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:DeleteObject"
-    ],
-    "Resource": ["arn:aws:s3:::<BUCKET>", "arn:aws:s3:::*/*"]
+  	"Version": "2012-10-17",
+  	"Statement": [
+      {
+        "Sid": "S3ObjectAccess",
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject"
+        ],
+        "Resource": ["arn:aws:s3:::<BUCKET>/*"]
+      },
+      {
+        "Sid": "S3ListAccess",
+        "Effect": "Allow",
+        "Action": [
+          "s3:ListBucket",
+        ],
+        "Resource": ["arn:aws:s3:::<BUCKET>"]
+      }
+    ]
   }
   ```
 
@@ -100,6 +112,25 @@ Access control to the remote is ensured via IAM permissions, and can be controll
 - bucket level
 - prefix level (you can use prefixes to store multiple repos in the same S3 bucket thus minimizing the setup effort)
 - KMS key level
+
+If you store multiple repos in a single bucket but would like to spearate permissions to access each repo, you can do so by modifying the resource definition in the policy to specify the repo prefix:
+
+```json
+      {
+        "Sid": "S3ObjectAccess",
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject"
+        ],
+        "Resource": ["arn:aws:s3:::<BUCKET>/<REPO>/*"]
+      },
+```
+
+Be aware that this would not prevent users with permissions on other repos to list the content of any repo of the bucket. This is because the `s3:ListBucket` permission, which is required for the correct operation of the tool, is scoped at the bucket level.
+
+If an higher level of isolation is required, the solution is to use different buckets.
 
 ## Use S3 remotes
 


### PR DESCRIPTION
Added clarification on the s3 operations permission and the implications they have in term of security

*Issue #, if available:*

*Description of changes:*
Added clarifications on the Amazon S3 bucket permission required in the IAM policy for the tool and their implications 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
