### PR TITLE
feat: automatic publish git flow

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0 # Fetch all history for all branches and tags
+
+      - name: Check if tag is on main branch
+        id: check_tag
+        run: |
+          # Check if the tag commit is on the main branch
+          if git merge-base --is-ancestor ${GITHUB_SHA} origin/main; then
+            echo "Tag is on main branch, proceeding with release"
+            echo "on_main=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag is not on main branch, skipping release"
+            echo "on_main=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Set up Python
+        if: steps.check_tag.outputs.on_main == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        if: steps.check_tag.outputs.on_main == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Set Poetry version
+        if: steps.check_tag.outputs.on_main == 'true'
+        run: |
+          # Remove 'v' prefix from tag name if present
+          VERSION=${GITHUB_REF_NAME#v}
+          poetry version $VERSION
+
+      - name: Build package
+        if: steps.check_tag.outputs.on_main == 'true'
+        run: |
+          poetry build
+
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.on_main == 'true'
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry publish
+
+      - name: Create Release
+        if: steps.check_tag.outputs.on_main == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_name="${GITHUB_REF_NAME}"
+          gh release create "${tag_name}" --generate-notes
+          for package in $(ls dist/*.whl dist/*.gz); do
+            gh release upload "${tag_name}" "$package" --clobber
+          done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a github flow to automatically create a released in Github and publish the library to PyPi when a new tag is pushed on the main branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
