### PR TITLE
Fix verbosity option to work with early credential errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,19 @@ If an object with the same key already exists, git-lfs-s3 does not upload it aga
 
 ### Debugging
 
-Use `--verbose` flag to print some debug information when performing git operations. Logs will be put to stderr.
+Use `--verbose` flag or set `transfer.verbosity=2` to print debug information when performing git operations:
+
+```bash
+git -c transfer.verbosity=2 push origin main
+```
+
+For early errors (like credential issues), use the environment variable:
+
+```bash
+GIT_REMOTE_S3_VERBOSE=1 git push origin main
+```
+
+Logs will be put to stderr.
 
 For LFS operations you can enable and disable debug logging via `git-lfs-s3 enable-debug` and `git-lfs-s3 disable-debug` respectively. Logs are put in `.git/lfs/tmp/git-lfs-s3.log` in the repo.
 

--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -25,7 +25,11 @@ import botocore
 
 logger = logging.getLogger(__name__)
 if "remote" in __name__:
-    logging.basicConfig(level=logging.ERROR, stream=sys.stderr)
+    # Check for early verbosity via environment variable
+    verbose_env = os.environ.get('GIT_REMOTE_S3_VERBOSE', '').lower() in ('1', 'true', 'yes')
+    log_level = logging.INFO if verbose_env else logging.ERROR
+    logging.basicConfig(level=log_level, stream=sys.stderr,
+                        format='%(name)s: %(levelname)s: %(message)s')
 
 
 class BucketNotFoundError(Exception):
@@ -264,6 +268,8 @@ class S3Remote:
     def cmd_option(self, arg: str):
         option, value = arg.split(" ")[1:]
         if option == "verbosity" and int(value) >= 2:
+            # Set both root logger and module logger for complete verbosity
+            logging.getLogger().setLevel(logging.INFO)
             logger.setLevel(logging.INFO)
             sys.stdout.write("ok\n")
         else:


### PR DESCRIPTION
- Add GIT_REMOTE_S3_VERBOSE environment variable support for early verbosity

- Configure both root and module loggers in cmd_option for complete verbosity

- Update README.md with new debugging options

- Fixes issue where --verbose flag didn't work with credential errors

The problem was that logging.basicConfig() set the root logger level to ERROR at import time, and cmd_option only modified the module logger. Early errors like AWS credential issues were logged before the verbosity option could be processed, causing them to be suppressed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
