### PR TITLE
Issue #45: fix s3 bucket prefix construction for refs in `delete` command 

### DIFF
--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -173,7 +173,7 @@ class S3Remote:
         logger.info(f"Removing remote ref {remote_ref}")
         try:
             objects_to_delete = self.s3.list_objects_v2(
-                Bucket=self.bucket, Prefix=f"{self.prefix}/{remote_ref}"
+                Bucket=self.bucket, Prefix=f"{self.prefix}/{remote_ref}/"
             ).get("Contents", [])
             if (
                 self.uri_scheme == UriScheme.S3
@@ -184,8 +184,10 @@ class S3Remote:
                 for object in objects_to_delete:
                     self.s3.delete_object(Bucket=self.bucket, Key=object["Key"])
                 return f"ok {remote_ref}\n"
-            else:
+            elif len(objects_to_delete) == 0:
                 return f"error {remote_ref} not found\n"
+            else:
+                return f'error {remote_ref} "multiple bundles exists on server. Run git-s3 doctor to fix."?\n'  # noqa: B950
 
         except ClientError as e:
             if e.response["Error"]["Code"] == "404":


### PR DESCRIPTION
re Issue #45: fix s3 bucket prefix construction for refs in `delete` command

Currently, the `delete` command builds up the s3 bucket prefix without a trailing forward slash. These leads to a bug where attempting to delete a branch whose name prefixes another existing branch name will result in "not found" error.
This happens because s3 will resolve the prefix two all refs whose keys share the same prefix provided to `ListObjectsV2`. There's an additional bug, where if the number of objects return != 1 (or 2 for zip schemes), then the `delete` command assumes the number of objects is 0 and returns a "not found" err.

Fix this by:
1. appending a trailing forward slash to the ref name to break any possible substring prefix matches on branch name. This matches existing `ListObjectsV2` calls in the library that append a trailing `/`.  e.g. see `get_bundles_for_ref`, `remote_remote_ref`
2. add additional error handling to distinguish between true "not found" [0 objects found] vs duplicate refs found [>1 objects found].

Test plan:
- `git checkout -b boba && git push`
- `git checkout -b boba-fett && git push`
- `git push --delete origin boba`
- [x] Confirmed deleting `boba` now works even when `boba-fett` already exists in the remote s3 bucket.