### PR TITLE
Handle KeyboardInterrupt during parallel fetch

### DIFF
--- a/git_remote_s3/remote.py
+++ b/git_remote_s3/remote.py
@@ -486,14 +486,22 @@ class S3Remote:
         logger.info(f"Processing {len(cmds)} fetch commands in parallel")
 
         # Use a thread pool to process fetch commands in parallel
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor = concurrent.futures.ThreadPoolExecutor()
+        try:
             # Submit all fetch commands to the thread pool
             futures = [executor.submit(self.cmd_fetch, cmd) for cmd in cmds]
 
             # Wait for all fetch commands to complete
             concurrent.futures.wait(futures)
-
-        logger.info(f"Completed processing {len(cmds)} fetch commands in parallel")
+            logger.info(f"Completed processing {len(cmds)} fetch commands in parallel")
+        except KeyboardInterrupt:
+            # Cancel pending futures and shutdown immediately on Ctrl+C
+            for future in futures:
+                future.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        finally:
+            executor.shutdown(wait=False)
 
     def process_cmd(self, cmd: str):  # noqa: C901
         if cmd.startswith("fetch"):


### PR DESCRIPTION
After adding a progress bar, I noticed that canceling git clone would not actually stop the download threads. The background thread would keep writing. This may have caused issues reported by users who claimed cloning an S3-stored repo would never work. I think what they experienced was not seeing any output for a long time with `git clone`, then canceling and trying again. I'm guessing their second download attempt was clobbered by the still-running original thread.

Refactor executor to explicit try/finally so that Ctrl+C cancels pending futures and shuts down immediately. The cancellation isn't instant (I think boto3 will still finish the current chunk), but I see the background thread exit within a few seconds. 

My motivation is I'm dealing with a repo that has many branches with ~1GB bundles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
